### PR TITLE
Add cache timeout and SSL verification configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Optional:
   `server1:user:p4ss,server2:user:p4ass`.
 - `ROUTEMASTER_QUEUE_NAME`: if using the cache, on which Resque queue the cache
   population jobs should be enqueued.
-
-
+- `ROUTEMASTER_CACHE_TIMEOUT`: if using the cache, how long before Faraday will timeout fetching the resource. Defaults to 1 second.
+- `ROUTEMASTER_CACHE_VERIFY_SSL`: if using the cache, whether to verify SSL when fetching the resource. Defaults to false.
 
 ## Illustrated use cases
 

--- a/lib/routemaster/fetcher.rb
+++ b/lib/routemaster/fetcher.rb
@@ -39,7 +39,7 @@ module Routemaster
     end
 
     private
-    
+
     def _connection
       @_connection ||= Faraday.new do |f|
         f.request  :retry, max: 2, interval: 100e-3, backoff_factor: 2
@@ -48,10 +48,9 @@ module Routemaster
         f.response :json, content_type: /\bjson/
         f.adapter  :net_http_persistent
 
-        # TODO: make these configurable
-        f.options.timeout      = 1.0
-        f.options.open_timeout = 1.0
-        f.ssl.verify           = false
+        f.options.timeout      = ENV.fetch('ROUTEMASTER_CACHE_TIMEOUT', 1).to_f
+        f.options.open_timeout = ENV.fetch('ROUTEMASTER_CACHE_TIMEOUT', 1).to_f
+        f.ssl.verify           = ENV.fetch('ROUTEMASTER_CACHE_VERIFY_SSL', 'false') == 'true'
       end
     end
 


### PR DESCRIPTION
:clock10: Add cache timeout values to the `Faraday` call for the cache. Useful when you have a slow resource server, such as in development.
:lock: Allow overriding the SSL verification to have it off in development, but on in production.
:memo: All defaults for these values remain the same as before.